### PR TITLE
Unhide dots on German Umlaut O

### DIFF
--- a/TEF6686_ESP32.ino
+++ b/TEF6686_ESP32.ino
@@ -167,7 +167,7 @@ int volume;
 int XDRBWset;
 int XDRBWsetold;
 int xPos = 6;
-int yPos = 2;
+int yPos = 4;
 int16_t OStatus;
 int16_t SAvg;
 int16_t SAvg2;


### PR DESCRIPTION
`Ö` is now displayed as `Ö` and no more as `O` due to cropping.

# before

![grafik](https://github.com/PE5PVB/TEF6686_ESP32/assets/24510556/ee5b51dc-d38e-4995-b82a-a720bc4c5a4a)

# after

![grafik](https://github.com/PE5PVB/TEF6686_ESP32/assets/24510556/418fb5b1-dad4-4ea1-95c8-87c80c295c3b)
