### PR TITLE
Fixed OIRT band ends

### DIFF
--- a/src/TEF6686.h
+++ b/src/TEF6686.h
@@ -47,8 +47,8 @@ enum RADIO_TUNE_MODE {
 #define FREQ_SW_HIGH_EDGE_MAX      (FREQ_SW_END)
 #define FREQ_FM_START              65000
 #define FREQ_FM_END                108000
-#define FREQ_FM_OIRT_START         6540
-#define FREQ_FM_OIRT_END           7800
+#define FREQ_FM_OIRT_START         6575   // use values of 1/10 * kHz
+#define FREQ_FM_OIRT_END           7400   // use values of 1/10 * kHz
 
 // according to https://www.short-wave.info/index.php?feature=frequencies
 #define FREQ_SW_START       1800


### PR DESCRIPTION
lowest used frequency in Russia: 65,75 MHz, then 30 kHz steps, 
highest used frequency in Russia: 73,97 MHz 
(but we need to set it to 74 MHz in order to continue then with 50 kHz steps)

This fixes an offset of 10 kHz compared to the real frequencies.

Source: https://www.fmlist.org

Remark: line 50 in https://github.com/andimik/TEF6686_ESP32/blob/fb2edabe7147d21dc3f12f2036cef027923c7607/src/TEF6686.h#L50 and line 51 need to be set **not** in kHz, but 1/10 x kHz value. Don't know why.
