### PR TITLE
QFix - battery value blinkin TEF6686_ESP32.ino

### DIFF
--- a/TEF6686_ESP32.ino
+++ b/TEF6686_ESP32.ino
@@ -2960,7 +2960,6 @@ void ShowBattery() {
       } else {
         tft.drawRect(277, 6, 37, 20, ActiveColor);
         tft.fillRect(313, 13, 4, 6, ActiveColor);
-        tft.fillRect(279, 8, 33, 16, BackgroundColor);
         if (!batteryoptions == BATTERY_VALUE || !batteryoptions == BATTERY_PERCENT) {
           tft.fillRect(279, 24 - (battery * 4), 33, battery * 4, BarInsignificantColor);
         }

--- a/TEF6686_ESP32.ino
+++ b/TEF6686_ESP32.ino
@@ -154,7 +154,7 @@ byte screensaverOptions[5] = {0, 3, 10, 30, 60};
 byte screensaverset;
 byte showmodulation;
 byte showSWMIBand;
-byte nowToggleSWMIBand = 0;
+byte nowToggleSWMIBand = 1;
 byte SNRold;
 byte stepsize;
 byte StereoLevel;


### PR DESCRIPTION
It looks like this overrides the values in percentage and voltage display when they reach certain values.
This applies to the bug where the battery value indicator are blinking.
I am unable to provoke the problem after removing this line. Delete if I'm completely off track.