### PR TITLE
Allow current frequency when AF list is unsorted

### DIFF
--- a/src/TEF6686.cpp
+++ b/src/TEF6686.cpp
@@ -536,7 +536,7 @@ void TEF6686::readRDS(bool showrdserrors)
 
                     bool isValuePresent = false;
                     for (int i = 0; i < 50; i++) {
-                      if (buffer0 == currentfreq || buffer0 == 0 || af[i].frequency == buffer0) {
+                      if (rds.sortaf && (buffer0 == currentfreq) || buffer0 == 0 || af[i].frequency == buffer0) {
                         isValuePresent = true;
                         break;
                       }
@@ -550,7 +550,7 @@ void TEF6686::readRDS(bool showrdserrors)
 
                     isValuePresent = false;
                     for (int i = 0; i < 50; i++) {
-                      if (buffer1 == currentfreq || buffer1 == 0 || af[i].frequency == buffer1) {
+                      if (rds.sortaf && (buffer1 == currentfreq) || buffer1 == 0 || af[i].frequency == buffer1) {
                         isValuePresent = true;
                         break;
                       }


### PR DESCRIPTION
The position of the tuned frequency in the original order AF list can help with working out the transmitter. It seems logical to not filter it when sort AF is disabled.