### PR TITLE
Do not filter current frequency in unsorted AF list

### DIFF
--- a/src/TEF6686.cpp
+++ b/src/TEF6686.cpp
@@ -703,7 +703,7 @@ void TEF6686::readRDS(byte showrdserrors)
 
                   bool isValuePresent = false;
                   for (int i = 0; i < 50; i++) {                                                // Check if already in list
-                    if ((buffer0 == currentfreq) || buffer0 == 0 || af[i].frequency == buffer0) {
+                    if (rds.sortaf && (buffer0 == currentfreq) || buffer0 == 0 || af[i].frequency == buffer0) {
                       isValuePresent = true;
                       break;
                     }
@@ -717,7 +717,7 @@ void TEF6686::readRDS(byte showrdserrors)
 
                   isValuePresent = false;
                   for (int i = 0; i < 50; i++) {                                                // Check if already in list
-                    if ((buffer1 == currentfreq) || buffer1 == 0 || af[i].frequency == buffer1) {
+                    if (rds.sortaf && (buffer1 == currentfreq) || buffer1 == 0 || af[i].frequency == buffer1) {
                       isValuePresent = true;
                       break;
                     }


### PR DESCRIPTION
When AF sort is disabled, do not remove the current tuned frequency from the list.