### PR TITLE
Fix unsorted AF logic

### DIFF
--- a/src/TEF6686.cpp
+++ b/src/TEF6686.cpp
@@ -719,7 +719,7 @@ void TEF6686::readRDS(byte showrdserrors)
 
                   bool isValuePresent = false;
                   for (int i = 0; i < 50; i++) {                                                // Check if already in list
-                    if (rds.sortaf && ((buffer0 == currentfreq) || buffer0 == 0 || af[i].frequency == buffer0)) {
+                    if ((rds.sortaf && (buffer0 == currentfreq)) || buffer0 == 0 || af[i].frequency == buffer0) {
                       isValuePresent = true;
                       break;
                     }
@@ -733,7 +733,7 @@ void TEF6686::readRDS(byte showrdserrors)
 
                   isValuePresent = false;
                   for (int i = 0; i < 50; i++) {                                                // Check if already in list
-                    if (rds.sortaf && ((buffer1 == currentfreq) || buffer1 == 0 || af[i].frequency == buffer1)) {
+                    if ((rds.sortaf && (buffer1 == currentfreq)) || buffer1 == 0 || af[i].frequency == buffer1) {
                       isValuePresent = true;
                       break;
                     }


### PR DESCRIPTION
Include current frequency if AF sort is disabled, but keep other conditions separate, to avoid repeated AF list with 0.0 values