### PR TITLE
links to zip-files for external libraries instead of repository

### DIFF
--- a/TEF6686_ESP32.ino
+++ b/TEF6686_ESP32.ino
@@ -4,9 +4,9 @@
 #include <EEPROM.h>
 #include <Wire.h>
 #include <math.h>
-#include <ESP32Time.h>              // https://github.com/fbiego/ESP32Time
-#include <TFT_eSPI.h>               // https://github.com/ohmytime/TFT_eSPI_DynamicSpeed (Modified version)
-#include <Hash.h>                   // https://github.com/bbx10/Hash_tng
+#include <ESP32Time.h>              // https://github.com/fbiego/ESP32Time/archive/refs/heads/main.zip
+#include <TFT_eSPI.h>               // https://github.com/ohmytime/TFT_eSPI_DynamicSpeed/archive/refs/heads/master.zip (please then edit the User_Setup.h as described in the Wiki)
+#include <Hash.h>                   // https://github.com/bbx10/Hash_tng/archive/refs/heads/master.zip
 #include "src/WiFiConnect.h"
 #include "src/WiFiConnectParam.h"
 #include "src/FONT16.h"


### PR DESCRIPTION
- in a Github repository it's not so easy to find the download button for the zip file, which is needed for the Arduino IDE setup.
- added a hint that the `User_Setup.h` file needs to be edited afterwards