### PR TITLE
Send DX scan results to rabbitears.info map for North America

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -209,9 +209,9 @@
 #define EE_CHECKBYTE_VALUE          10     // 0 ~ 255,add new entry, change for new value
 #define EE_PRESETS_FREQUENCY        0     // Default value when memory channel should be skipped!
 #ifdef HAS_AIR_BAND
-#define EE_TOTAL_CNT                2236  // Total occupied eeprom bytes
+#define EE_TOTAL_CNT                2258  // Total occupied eeprom bytes
 #else
-#define EE_TOTAL_CNT                2230  // Total occupied eeprom bytes
+#define EE_TOTAL_CNT                2253  // Total occupied eeprom bytes
 #endif
 
 #define EE_PRESETS_BAND_START       0     // 99 * 1 byte
@@ -320,9 +320,11 @@
 #define EE_BYTE_MEMSTOPPOS          2227
 #define EE_BYTE_MEMPIONLY           2228
 #define EE_BYTE_MEMDOUBLEPI         2229
+#define EE_STRING_RABBITEARSUSER     2230
+#define EE_STRING_RABBITEARSPASSWORD 2241
 #ifdef HAS_AIR_BAND
-#define EE_BYTE_AIRSTEPSIZE         2230
-#define EE_UINT16_FREQUENCY_AIR     2231
+#define EE_BYTE_AIRSTEPSIZE         2252
+#define EE_UINT16_FREQUENCY_AIR     2253
 #endif
 // End of EEPROM index defines
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -4455,17 +4455,33 @@ void DoMenu() {
               tftPrint(0, "http://192.168.4.1", 155, 174, PrimaryColor, PrimaryColorSmooth, 16);
               char key [9];
               XDRGTK_key.toCharArray(key, 9);
+              char rabbitearsuser [9];
+              RabbitearsUser.toCharArray(rabbitearsuser, 9);
+              char rabbitearspw [9];
+              RabbitearsPassword.toCharArray(rabbitearspw, 9);
               UpdateFonts(1);
               WiFiConnectParam XDRGTK_key_text("Set XDRGTK Password: (max 8 characters)");
               WiFiConnectParam XDRGTK_key_input("XDRGTK_key", "Password", key, 9);
+              WiFiConnectParam RabbitearsUser_text("Set rabbitears.info live bandscan user ID");
+              WiFiConnectParam RabbitearsUser_input("RabbitearsUser", "ID", rabbitearsuser, 9);
+              WiFiConnectParam RabbitearsPassword_text("Set rabbitears.info password");
+              WiFiConnectParam RabbitearsPassword_input("RabbitearsPassword", "Password", rabbitearspw, 9);
               if (!setWiFiConnectParam) {
                 wc.addParameter(&XDRGTK_key_text);
                 wc.addParameter(&XDRGTK_key_input);
+                wc.addParameter(&RabbitearsUser_text);
+                wc.addParameter(&RabbitearsUser_input);
+                wc.addParameter(&RabbitearsPassword_text);
+                wc.addParameter(&RabbitearsPassword_input);
                 setWiFiConnectParam = true;
               }
               wc.startConfigurationPortal(AP_WAIT);
               XDRGTK_key = XDRGTK_key_input.getValue();
+              RabbitearsUser = RabbitearsUser_input.getValue();
+              RabbitearsPassword = RabbitearsPassword_input.getValue();
               EEPROM.writeString(EE_STRING_XDRGTK_KEY, XDRGTK_key);
+              EEPROM.writeString(EE_STRING_RABBITEARSUSER, RabbitearsUser);
+              EEPROM.writeString(EE_STRING_RABBITEARSPASSWORD, RabbitearsPassword);
               EEPROM.commit();
               UpdateFonts(0);
               wifi = true;

--- a/src/gui.h
+++ b/src/gui.h
@@ -196,6 +196,8 @@ extern String rds_clockold;
 extern String stationIDold;
 extern String stationStateold;
 extern String XDRGTK_key;
+extern String RabbitearsUser;
+extern String RabbitearsPassword;
 extern unsigned int ConverterSet;
 extern unsigned int HighEdgeSet;
 extern unsigned int LowEdgeSet;


### PR DESCRIPTION
Send result of DX scan to map at [https://rabbitears.info/tvdx/fm_all_tuners](https://rabbitears.info/tvdx/fm_all_tuners)

Only frequency, time and PI code detected are sent.  Call sign derivation is done on rabbitears.info server so it may differ from what the radio says.  Time sent by radio is ignored if time reported is in future or more than 1/2 hour in the past.

Adds text fields to wi-fi setup to input user id and password for rabbitears.info

Scan results are only sent when there is at least one PI code detected, the radio is in North America mode and there is both a user ID and password  and the frequency is in 88.1-107.9MHz on 200 kHz steps.