### PR TITLE
fix for incorrect time

### DIFF
--- a/TEF6686_ESP32.ino
+++ b/TEF6686_ESP32.ino
@@ -5,6 +5,7 @@
 #include <EEPROM.h>
 #include <Wire.h>
 #include <math.h>
+#include <TimeLib.h>
 #include <ESP32Time.h>              // https://github.com/fbiego/ESP32Time/archive/refs/heads/main.zip
 #include <TFT_eSPI.h>               // https://github.com/ohmytime/TFT_eSPI_DynamicSpeed/archive/refs/heads/master.zip (please then edit the User_Setup.h as described in the Wiki)
 #include <Hash.h>                   // https://github.com/bbx10/Hash_tng/archive/refs/heads/master.zip
@@ -935,7 +936,9 @@ void loop() {
       byte i = (frequency / 10 - 881) / 2;
       if (!rabbitearspi[i]) {
         rabbitearspi[i] = radio.rds.correctPI;
-        rtc.getTime("%FT%TZ").toCharArray(rabbitearstime[i], 21);
+
+        const time_t epoch = rtc.getEpoch() + rtc.offset;
+        strftime(rabbitearstime[i], 21, "%FT%TZ", localtime(&epoch));
       }
     }
 

--- a/src/TEF6686.h
+++ b/src/TEF6686.h
@@ -578,12 +578,13 @@ typedef struct _rds_ {
   char stationState[3];
   char dabafeid[5];
   char dabafchannel[4];
-  uint16_t hour, minute, day, month, year, rdsA, rdsB, rdsC, rdsD, rdsErr, rdsStat, correctPI, rdsplusTag1, rdsplusTag2;
+  uint16_t rdsA, rdsB, rdsC, rdsD, rdsErr, rdsStat, correctPI, rdsplusTag1, rdsplusTag2;
+  time_t time;
+  int32_t offset;
   uint16_t aid[10];
   uint32_t dabaffreq;
   byte aid_counter;
   byte fastps;
-  int8_t offset;
   unsigned int ECC;
   unsigned int LIC;
   byte pinMin;
@@ -777,5 +778,7 @@ class TEF6686 {
     uint8_t eRTblock;
     uint8_t doublecounter;
     uint16_t doubletestfreq;
+    time_t lastrdstime;
+    int32_t lasttimeoffset;
 };
 #endif

--- a/src/rds.cpp
+++ b/src/rds.cpp
@@ -736,20 +736,23 @@ void showPS() {
 }
 
 void showCT() {
+  char str[6];
+  time_t t;
   if (!screenmute && showclock) {
     if (radio.rds.hasCT && !dropout) {
-      rds_clock = ((radio.rds.hour < 10 ? "0" : "") + String(radio.rds.hour) + ":" + (radio.rds.minute < 10 ? "0" : "") + String(radio.rds.minute));
+      t = radio.rds.time + radio.rds.offset;
     } else if (!radio.rds.hasCT || dropout) {
-      rds_clock = ((rtc.getHour(true) < 10 ? "0" : "") + String(rtc.getHour(true)) + ":" + (rtc.getMinute() < 10 ? "0" : "") + String(rtc.getMinute()));
+      t = rtc.getEpoch() + radio.rds.offset;
       if (dropout) {
-        radio.rds.hour = rtc.getHour(true);
-        radio.rds.minute = rtc.getMinute();
+        radio.rds.time = static_cast<time_t>(rtc.getEpoch());
       }
     }
+    strftime(str, 6, "%H:%M", localtime(&t));
+    rds_clock = String(str);
     if (rds_clock != rds_clockold || hasCTold != radio.rds.hasCT) {
       if (radio.rds.hasCT && RDSstatus) {
         rtcset = true;
-        rtc.setTime(0, radio.rds.minute, radio.rds.hour, radio.rds.day, radio.rds.month, radio.rds.year);
+        rtc.setTime(radio.rds.time);
         if (advancedRDS) {
           tftReplace(1, rds_clockold, rds_clock, 208, 109, RDSColor, RDSColorSmooth, BackgroundColor, 16);
         } else {


### PR DESCRIPTION
Fix for incorrect time displayed.  Use time_t for rds time (set to UTC), save offset separate so calendar date will be correct.  Set real time clock to UTC.  Ignore obviously wrong rds times.

Only set real time clock after two consecutive rds times are 60 seconds apart to avoid spurious group 4A message decodes.