### PR TITLE
More GUI optimizations

### DIFF
--- a/TEF6686_ESP32.ino
+++ b/TEF6686_ESP32.ino
@@ -3352,11 +3352,11 @@ void ShowSignalLevel() {
       } else {
         if (SStatusold / 10 != SStatusprint / 10) {
           tftReplace(1, String(SStatusold / 10), String(SStatusprint / 10),
-                     288, 105, FreqColor, FreqColorSmooth, BackgroundColor, 48);
+                     280, 104, FreqColor, FreqColorSmooth, BackgroundColor, 48);
         }
-        tftReplace(1, "." + String(abs(SStatusold % 10)),
-                   "." + String(abs(SStatusprint % 10)),
-                   310, 105, FreqColor, FreqColorSmooth, BackgroundColor, 28);
+        tftReplace(-1, "." + String(abs(SStatusold % 100)),
+                   "." + String(abs(SStatusprint % 100)),
+                   285, 102, FreqColor, FreqColorSmooth, BackgroundColor, 28);
 
         // Calculate segments for signal meter
         if (band < BAND_GAP) {
@@ -3659,7 +3659,7 @@ void showAutoSquelch(bool mode) {
     SquelchSprite.setTextColor(BackgroundColor, BackgroundColor, false);
   }
   SquelchSprite.fillSprite(BackgroundColor);
-  SquelchSprite.drawString(String(myLanguage[language][86]), 0, 0);
+  SquelchSprite.drawString("A.", 0, 0);
   SquelchSprite.pushSprite(235, 145);
 }
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -3036,8 +3036,8 @@ void BuildDisplay() {
     tftPrint(-1, "100", 164, 144, ActiveColor, ActiveColorSmooth, 16);
   }
 
-  tftPrint(-1, "kHz", 205, 4, ActiveColor, ActiveColorSmooth, 28);
-  tftPrint(-1, unitString[unit], 282, 145, ActiveColor, ActiveColorSmooth, 16);
+  tftPrint(1, "kHz", 246, 4, ActiveColor, ActiveColorSmooth, 28);
+  tftPrint(1, unitString[unit], 316, 128, ActiveColor, ActiveColorSmooth, 16);
 
   tft.drawBitmap(68, 5, RDSLogo, 35, 22, GreyoutColor);
   tft.drawBitmap(249, 4, Speaker, 28, 24, GreyoutColor);


### PR DESCRIPTION
- Moved unit strings higher to make space for other info.
- Replaced "automatic" string in squelch with static "A." to save space as well.
- Signal displays now two decimals (up for debate)