### PR TITLE
Add conditional support for displaying “Art. head” in DEEPELEC_DP_66X

### DIFF
--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -2985,7 +2985,11 @@ void BuildAdvancedRDS() {
   tftPrint(ALEFT, "LIC", 214, 208, ActiveColor, ActiveColorSmooth, 16);
   tftPrint(ALEFT, "PIN", 214, 223, ActiveColor, ActiveColorSmooth, 16);
   tftPrint(ARIGHT, "Dynamic PTY", 300, 130, ActiveColor, ActiveColorSmooth, 16);
-  tftPrint(ARIGHT, "Artificial head", 300, 145, ActiveColor, ActiveColorSmooth, 16);
+  #ifdef DEEPELEC_DP_66X
+    tftPrint(ARIGHT, "Art. head", 300, 145, ActiveColor, ActiveColorSmooth, 16);
+  #else
+    tftPrint(ARIGHT, "Artificial head", 300, 145, ActiveColor, ActiveColorSmooth, 16);
+  #endif
   tftPrint(ARIGHT, "Compressed", 300, 160, ActiveColor, ActiveColorSmooth, 16);
   tftPrint(ARIGHT, "Has stereo", 300, 175, ActiveColor, ActiveColorSmooth, 16);
 


### PR DESCRIPTION
Add conditional support for displaying “Art. head” in Advanced RDS when the model is DEEPELEC_DP_66X.

For the DEEPELEC_DP_66X model, the text length exceeds the available box width, causing layout overflow issues. Adjust the layout or text handling to prevent overflow when this model is selected.

<img width="529" height="316" alt="image" src="https://github.com/user-attachments/assets/8e27ac57-89bb-421f-9d7b-970145d0f89a" />
