### PR TITLE
Fix #899

### DIFF
--- a/src/WiFiConnectParam.cpp
+++ b/src/WiFiConnectParam.cpp
@@ -110,7 +110,6 @@ void WiFiConnectParam::init(const char *id, const char *placeholder, const char 
 /**************************************************************************/
 void WiFiConnectParam::setValue(const char *newValue){
   if(_length>0){
-  if (_value) delete[] _value;
   _value = new char[_length + 1];
   for (int i = 0; i < _length; i++) {
     _value[i] = 0;


### PR DESCRIPTION
Fixes the exception that occurs when trying to configure WiFi.

Makes WiFi usable, even tested