### PR TITLE
Fix XDRGTK volume not matching the volume shown in the menu

### DIFF
--- a/src/comms.cpp
+++ b/src/comms.cpp
@@ -860,10 +860,10 @@ void XDRGTKRoutine() {
             BWset = BWsetRecall;
             doBW();
             XDRScan = false;
-            if (VolSet != 0) {
+            if (!XDRMute) {
               radio.setUnMute();
               if (!screenmute) tft.drawBitmap(249, 4, Speaker, 28, 24, GreyoutColor);
-              radio.setVolume(((VolSet * 10) - 40) / 10);
+              radio.setVolume(VolSet);
             }
             break;
         }
@@ -897,8 +897,10 @@ void XDRGTKRoutine() {
         break;
 
       case 'Y':
-        VolSet = atoi(buff + 1);
-        if (VolSet == 0) {
+        int xdrvol;
+        xdrvol = atoi(buff + 1);
+        if (xdrvol == 0) {
+          VolSet = 0;
           radio.setMute();
           if (!screenmute) tft.drawBitmap(249, 4, Speaker, 28, 24, PrimaryColor);
           XDRMute = true;
@@ -906,11 +908,17 @@ void XDRGTKRoutine() {
         } else {
           radio.setUnMute();
           if (!screenmute) tft.drawBitmap(249, 4, Speaker, 28, 24, GreyoutColor);
-          radio.setVolume((VolSet - 40) / 10);
+          // VolSet holds the volume in dB and is what the menu shows, what is
+          // written to EEPROM and what is fed to setVolume everywhere else.
+          // Keep it equal to the level actually applied, or the display and
+          // the audio disagree.
+          VolSet = (xdrvol - 40) / 10;
+          if (VolSet > 10) VolSet = 10;
+          if (VolSet < -10) VolSet = -10;
+          radio.setVolume(VolSet);
           XDRMute = false;
         }
-        DataPrint("Y" + String(VolSet) + "\n");
-        VolSet /= 10;
+        DataPrint("Y" + String(xdrvol) + "\n");
         break;
 
       case 'x':


### PR DESCRIPTION
Fixes #891

`VolSet` holds the volume in dB. Everywhere else it is passed directly to `radio.setVolume()` (at boot, from the menu, and on XDRGTK disconnect), the menu displays the same value, and the same value only is written to EEPROM.

But in the `Y` handler one value was getting applied and a different value was getting stored:

```c
VolSet = atoi(buff + 1);              // x
radio.setVolume((VolSet - 40) / 10);  // applies (x - 40) / 10
VolSet /= 10;                         // stores x / 10
```

So there was always a 4 dB difference. For `Y100`, +6 was applied but +10 was shown.

## What this PR does

**1. `Y` handler stores the value it actually applies**

`VolSet` is now set to the same value that goes to `radio.setVolume()`, so the display, the EEPROM value and the audio all agree. The applied formula `(x - 40) / 10` is untouched, so there is no change in what you hear. A clamp to -10..+10 is added to match the range the menu already enforces. The reply still echoes the raw XDRGTK number, so the slider will not jump.

**2. Post-scan volume restore was dropping 4 dB when no `Y` was sent**

Line 863 was doing `radio.setVolume(((VolSet * 10) - 40) / 10)`, which assumes `VolSet` is on the XDRGTK scale. If XDRGTK is connected and a scan is run without ever sending a `Y` command, `VolSet` is still the plain menu value in dB, and this line was reducing it by 4 dB after every scan:

```
menu  +0 dB -> restored as  -4 dB
menu +10 dB -> restored as  +6 dB
```

Since `VolSet` now always holds the applied dB value, this becomes a plain `radio.setVolume(VolSet)` and is correct in both cases.

**3. The "not muted" check after a scan**

The same block was using `VolSet != 0` as a mute test. That was working only because of the old `x / 10` scale, and with the corrected scale it would misfire for x = 40..49, which is the middle of the slider. Changed it to `if (!XDRMute)`, which is the proper flag, set by the same `Y` and `X` handlers and already used for exactly this purpose in the .ino. This also fixes the older case where x = 1..9 was leaving the radio muted after a scan.

## Verification

I swept the full XDRGTK range x = 1..100 and compared the applied volume before and after this change. There are zero differences, so nothing changes in what you hear. The clamp never triggers, as the mapping only produces -4..+6.

One thing that does change on purpose: after an XDRGTK volume command the menu will now show a value 4 lower than before. That is the correction, but users who are used to the old reading will notice it.

This PR does not change the mapping itself. Currently 0..100 only covers -4..+6 dB out of the -10..+10 range. Kindly let me know if you want that also to be changed, I can do it in the same PR.

Compiles clean. I have not tested on hardware, as I do not have the tuner with me, so kindly verify once at your end.
